### PR TITLE
Update sub-project header treatment

### DIFF
--- a/HapInAVFoundation.xcodeproj/project.pbxproj
+++ b/HapInAVFoundation.xcodeproj/project.pbxproj
@@ -1472,8 +1472,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"\"$(TARGET_BUILD_DIR)/usr/local/include\"",
-					"\"$(DSTROOT)/usr/local/include\"",
+					"\"$(BUILT_PRODUCTS_DIR)/include/snappy\"",
+					"\"$(BUILT_PRODUCTS_DIR)/include/squish\"",
 				);
 				INFOPLIST_FILE = HapInAVFoundation/Info.plist;
 				INSTALL_PATH = "@rpath";
@@ -1499,8 +1499,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"\"$(TARGET_BUILD_DIR)/usr/local/include\"",
-					"\"$(DSTROOT)/usr/local/include\"",
+					"\"$(BUILT_PRODUCTS_DIR)/include/snappy\"",
+					"\"$(BUILT_PRODUCTS_DIR)/include/squish\"",
 				);
 				INFOPLIST_FILE = HapInAVFoundation/Info.plist;
 				INSTALL_PATH = "@rpath";

--- a/external/hap/hap.c
+++ b/external/hap/hap.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h> // For memcpy for uncompressed frames
-#include "snappy-c.h"
+#include <snappy-c.h>
 
 #define kHapUInt24Max 0x00FFFFFF
 

--- a/external/snappy/snappy-mac/snappy.xcodeproj/project.pbxproj
+++ b/external/snappy/snappy-mac/snappy.xcodeproj/project.pbxproj
@@ -11,28 +11,51 @@
 		1ACD310C207E45FC00EA8ADF /* snappy-sinksource.cc in Sources */ = {isa = PBXBuildFile; fileRef = E2830FD417E0C58E005E72C3 /* snappy-sinksource.cc */; };
 		1ACD310D207E45FE00EA8ADF /* snappy-stubs-internal.cc in Sources */ = {isa = PBXBuildFile; fileRef = E2830FD517E0C58E005E72C3 /* snappy-stubs-internal.cc */; };
 		1ACD310E207E460000EA8ADF /* snappy.cc in Sources */ = {isa = PBXBuildFile; fileRef = E2830FD717E0C58E005E72C3 /* snappy.cc */; };
-		1ACD310F207E461A00EA8ADF /* snappy.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE917E0C6EB005E72C3 /* snappy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1ACD3110207E461E00EA8ADF /* snappy-stubs-public.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE317E0C5AC005E72C3 /* snappy-stubs-public.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1ACD3111207E462300EA8ADF /* snappy-c.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FDF17E0C5AC005E72C3 /* snappy-c.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1ACD3112207E462A00EA8ADF /* snappy-sinksource.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE117E0C5AC005E72C3 /* snappy-sinksource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1ACD3113207E463700EA8ADF /* snappy-stubs-internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE217E0C5AC005E72C3 /* snappy-stubs-internal.h */; };
-		1ACD3114207E463B00EA8ADF /* snappy-internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE017E0C5AC005E72C3 /* snappy-internal.h */; };
-		1ACD3115207E464100EA8ADF /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D2440A17E1E9A9004D0C23 /* config.h */; };
 		E2830FD917E0C58E005E72C3 /* snappy-c.cc in Sources */ = {isa = PBXBuildFile; fileRef = E2830FD317E0C58E005E72C3 /* snappy-c.cc */; };
 		E2830FDA17E0C58E005E72C3 /* snappy-sinksource.cc in Sources */ = {isa = PBXBuildFile; fileRef = E2830FD417E0C58E005E72C3 /* snappy-sinksource.cc */; };
 		E2830FDB17E0C58E005E72C3 /* snappy-stubs-internal.cc in Sources */ = {isa = PBXBuildFile; fileRef = E2830FD517E0C58E005E72C3 /* snappy-stubs-internal.cc */; };
 		E2830FDD17E0C58E005E72C3 /* snappy.cc in Sources */ = {isa = PBXBuildFile; fileRef = E2830FD717E0C58E005E72C3 /* snappy.cc */; };
-		E2830FE417E0C5AC005E72C3 /* snappy-c.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FDF17E0C5AC005E72C3 /* snappy-c.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2830FE517E0C5AC005E72C3 /* snappy-internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE017E0C5AC005E72C3 /* snappy-internal.h */; };
-		E2830FE617E0C5AC005E72C3 /* snappy-sinksource.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE117E0C5AC005E72C3 /* snappy-sinksource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2830FE717E0C5AC005E72C3 /* snappy-stubs-internal.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE217E0C5AC005E72C3 /* snappy-stubs-internal.h */; };
-		E2830FE817E0C5AC005E72C3 /* snappy-stubs-public.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE317E0C5AC005E72C3 /* snappy-stubs-public.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2830FEA17E0C6EB005E72C3 /* snappy.h in Headers */ = {isa = PBXBuildFile; fileRef = E2830FE917E0C6EB005E72C3 /* snappy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2D2440B17E1E9A9004D0C23 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D2440A17E1E9A9004D0C23 /* config.h */; };
+		E2BF306A2326911E0098A022 /* snappy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FE917E0C6EB005E72C3 /* snappy.h */; };
+		E2BF306B2326911E0098A022 /* snappy-c.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FDF17E0C5AC005E72C3 /* snappy-c.h */; };
+		E2BF306C232691250098A022 /* snappy-sinksource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FE117E0C5AC005E72C3 /* snappy-sinksource.h */; };
+		E2BF306D232691250098A022 /* snappy-stubs-public.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FE317E0C5AC005E72C3 /* snappy-stubs-public.h */; };
+		E2BF306F232691B90098A022 /* snappy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FE917E0C6EB005E72C3 /* snappy.h */; };
+		E2BF3070232691B90098A022 /* snappy-c.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FDF17E0C5AC005E72C3 /* snappy-c.h */; };
+		E2BF3071232691B90098A022 /* snappy-sinksource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FE117E0C5AC005E72C3 /* snappy-sinksource.h */; };
+		E2BF3072232691B90098A022 /* snappy-stubs-public.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E2830FE317E0C5AC005E72C3 /* snappy-stubs-public.h */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		E2BF30692326910B0098A022 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = include/snappy;
+			dstSubfolderSpec = 16;
+			files = (
+				E2BF306C232691250098A022 /* snappy-sinksource.h in CopyFiles */,
+				E2BF306D232691250098A022 /* snappy-stubs-public.h in CopyFiles */,
+				E2BF306A2326911E0098A022 /* snappy.h in CopyFiles */,
+				E2BF306B2326911E0098A022 /* snappy-c.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2BF306E232691AC0098A022 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = include/snappy;
+			dstSubfolderSpec = 16;
+			files = (
+				E2BF306F232691B90098A022 /* snappy.h in CopyFiles */,
+				E2BF3070232691B90098A022 /* snappy-c.h in CopyFiles */,
+				E2BF3071232691B90098A022 /* snappy-sinksource.h in CopyFiles */,
+				E2BF3072232691B90098A022 /* snappy-stubs-public.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		1A724729207E442C0099ED5A /* libsnappy.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsnappy.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A724729207E442C0099ED5A /* lib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = lib.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2830FCA17E0C43A005E72C3 /* libsnappy.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libsnappy.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2830FD317E0C58E005E72C3 /* snappy-c.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "snappy-c.cc"; path = "../snappy-source/snappy-c.cc"; sourceTree = "<group>"; };
 		E2830FD417E0C58E005E72C3 /* snappy-sinksource.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "snappy-sinksource.cc"; path = "../snappy-source/snappy-sinksource.cc"; sourceTree = "<group>"; };
@@ -110,37 +133,6 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		1A724727207E442C0099ED5A /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1ACD310F207E461A00EA8ADF /* snappy.h in Headers */,
-				1ACD3110207E461E00EA8ADF /* snappy-stubs-public.h in Headers */,
-				1ACD3111207E462300EA8ADF /* snappy-c.h in Headers */,
-				1ACD3112207E462A00EA8ADF /* snappy-sinksource.h in Headers */,
-				1ACD3113207E463700EA8ADF /* snappy-stubs-internal.h in Headers */,
-				1ACD3114207E463B00EA8ADF /* snappy-internal.h in Headers */,
-				1ACD3115207E464100EA8ADF /* config.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E2830FC817E0C43A005E72C3 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E2830FEA17E0C6EB005E72C3 /* snappy.h in Headers */,
-				E2830FE817E0C5AC005E72C3 /* snappy-stubs-public.h in Headers */,
-				E2830FE417E0C5AC005E72C3 /* snappy-c.h in Headers */,
-				E2830FE617E0C5AC005E72C3 /* snappy-sinksource.h in Headers */,
-				E2830FE717E0C5AC005E72C3 /* snappy-stubs-internal.h in Headers */,
-				E2830FE517E0C5AC005E72C3 /* snappy-internal.h in Headers */,
-				E2D2440B17E1E9A9004D0C23 /* config.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
 		1A724728207E442C0099ED5A /* snappy-static */ = {
 			isa = PBXNativeTarget;
@@ -148,7 +140,7 @@
 			buildPhases = (
 				1A724725207E442C0099ED5A /* Sources */,
 				1A724726207E442C0099ED5A /* Frameworks */,
-				1A724727207E442C0099ED5A /* Headers */,
+				E2BF306E232691AC0098A022 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -156,7 +148,7 @@
 			);
 			name = "snappy-static";
 			productName = "snappy-static";
-			productReference = 1A724729207E442C0099ED5A /* libsnappy.a */;
+			productReference = 1A724729207E442C0099ED5A /* lib.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		E2830FC917E0C43A005E72C3 /* snappy */ = {
@@ -165,7 +157,7 @@
 			buildPhases = (
 				E2830FC617E0C43A005E72C3 /* Sources */,
 				E2830FC717E0C43A005E72C3 /* Frameworks */,
-				E2830FC817E0C43A005E72C3 /* Headers */,
+				E2BF30692326910B0098A022 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/external/squish/squish.xcodeproj/project.pbxproj
+++ b/external/squish/squish.xcodeproj/project.pbxproj
@@ -16,20 +16,6 @@
 		1AF9A2F9207E46B600C87889 /* alpha.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D563417E0E06E008DD459 /* alpha.cpp */; };
 		1AF9A2FA207E46B600C87889 /* colourset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D563517E0E06E008DD459 /* colourset.cpp */; };
 		1AF9A2FB207E46B600C87889 /* maths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D563617E0E06E008DD459 /* maths.cpp */; };
-		1AF9A2FC207E46BA00C87889 /* clusterfit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564117E0E0A4008DD459 /* clusterfit.h */; };
-		1AF9A2FD207E46BA00C87889 /* colourblock.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564217E0E0A4008DD459 /* colourblock.h */; };
-		1AF9A2FE207E46BA00C87889 /* colourfit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564317E0E0A4008DD459 /* colourfit.h */; };
-		1AF9A2FF207E46BA00C87889 /* rangefit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564417E0E0A4008DD459 /* rangefit.h */; };
-		1AF9A300207E46BA00C87889 /* singlecolourfit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564517E0E0A4008DD459 /* singlecolourfit.h */; };
-		1AF9A301207E46BA00C87889 /* alpha.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564617E0E0A4008DD459 /* alpha.h */; };
-		1AF9A302207E46BA00C87889 /* colourset.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564717E0E0A4008DD459 /* colourset.h */; };
-		1AF9A303207E46BA00C87889 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564817E0E0A4008DD459 /* config.h */; };
-		1AF9A304207E46BA00C87889 /* maths.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564917E0E0A4008DD459 /* maths.h */; };
-		1AF9A305207E46BA00C87889 /* simd_float.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564A17E0E0A4008DD459 /* simd_float.h */; };
-		1AF9A306207E46BA00C87889 /* simd_sse.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564B17E0E0A4008DD459 /* simd_sse.h */; };
-		1AF9A307207E46BA00C87889 /* simd_ve.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564C17E0E0A4008DD459 /* simd_ve.h */; };
-		1AF9A308207E46BA00C87889 /* simd.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564D17E0E0A4008DD459 /* simd.h */; };
-		1AF9A309207E46BA00C87889 /* squish.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564E17E0E0A4008DD459 /* squish.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E25D563817E0E06E008DD459 /* clusterfit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D562E17E0E06E008DD459 /* clusterfit.cpp */; };
 		E25D563917E0E06E008DD459 /* colourblock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D562F17E0E06E008DD459 /* colourblock.cpp */; };
 		E25D563A17E0E06E008DD459 /* colourfit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D563017E0E06E008DD459 /* colourfit.cpp */; };
@@ -39,21 +25,32 @@
 		E25D563E17E0E06E008DD459 /* alpha.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D563417E0E06E008DD459 /* alpha.cpp */; };
 		E25D563F17E0E06E008DD459 /* colourset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D563517E0E06E008DD459 /* colourset.cpp */; };
 		E25D564017E0E06E008DD459 /* maths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E25D563617E0E06E008DD459 /* maths.cpp */; };
-		E25D564F17E0E0A4008DD459 /* clusterfit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564117E0E0A4008DD459 /* clusterfit.h */; };
-		E25D565017E0E0A4008DD459 /* colourblock.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564217E0E0A4008DD459 /* colourblock.h */; };
-		E25D565117E0E0A4008DD459 /* colourfit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564317E0E0A4008DD459 /* colourfit.h */; };
-		E25D565217E0E0A4008DD459 /* rangefit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564417E0E0A4008DD459 /* rangefit.h */; };
-		E25D565317E0E0A4008DD459 /* singlecolourfit.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564517E0E0A4008DD459 /* singlecolourfit.h */; };
-		E25D565417E0E0A4008DD459 /* alpha.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564617E0E0A4008DD459 /* alpha.h */; };
-		E25D565517E0E0A4008DD459 /* colourset.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564717E0E0A4008DD459 /* colourset.h */; };
-		E25D565617E0E0A4008DD459 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564817E0E0A4008DD459 /* config.h */; };
-		E25D565717E0E0A4008DD459 /* maths.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564917E0E0A4008DD459 /* maths.h */; };
-		E25D565817E0E0A4008DD459 /* simd_float.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564A17E0E0A4008DD459 /* simd_float.h */; };
-		E25D565917E0E0A4008DD459 /* simd_sse.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564B17E0E0A4008DD459 /* simd_sse.h */; };
-		E25D565A17E0E0A4008DD459 /* simd_ve.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564C17E0E0A4008DD459 /* simd_ve.h */; };
-		E25D565B17E0E0A4008DD459 /* simd.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564D17E0E0A4008DD459 /* simd.h */; };
-		E25D565C17E0E0A4008DD459 /* squish.h in Headers */ = {isa = PBXBuildFile; fileRef = E25D564E17E0E0A4008DD459 /* squish.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E2BF3066232690250098A022 /* squish.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E25D564E17E0E0A4008DD459 /* squish.h */; };
+		E2BF3068232690FF0098A022 /* squish.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E25D564E17E0E0A4008DD459 /* squish.h */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		E2BF3065232690120098A022 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = include/squish;
+			dstSubfolderSpec = 16;
+			files = (
+				E2BF3066232690250098A022 /* squish.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E2BF3067232690EF0098A022 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = include/squish;
+			dstSubfolderSpec = 16;
+			files = (
+				E2BF3068232690FF0098A022 /* squish.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		1AF9A2EA207E468300C87889 /* libsquish.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsquish.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -160,51 +157,6 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		1AF9A2E8207E468300C87889 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1AF9A309207E46BA00C87889 /* squish.h in Headers */,
-				1AF9A308207E46BA00C87889 /* simd.h in Headers */,
-				1AF9A305207E46BA00C87889 /* simd_float.h in Headers */,
-				1AF9A300207E46BA00C87889 /* singlecolourfit.h in Headers */,
-				1AF9A2FF207E46BA00C87889 /* rangefit.h in Headers */,
-				1AF9A2FE207E46BA00C87889 /* colourfit.h in Headers */,
-				1AF9A301207E46BA00C87889 /* alpha.h in Headers */,
-				1AF9A303207E46BA00C87889 /* config.h in Headers */,
-				1AF9A302207E46BA00C87889 /* colourset.h in Headers */,
-				1AF9A304207E46BA00C87889 /* maths.h in Headers */,
-				1AF9A2FD207E46BA00C87889 /* colourblock.h in Headers */,
-				1AF9A2FC207E46BA00C87889 /* clusterfit.h in Headers */,
-				1AF9A307207E46BA00C87889 /* simd_ve.h in Headers */,
-				1AF9A306207E46BA00C87889 /* simd_sse.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E25D562317E0E02B008DD459 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E25D565C17E0E0A4008DD459 /* squish.h in Headers */,
-				E25D565B17E0E0A4008DD459 /* simd.h in Headers */,
-				E25D565817E0E0A4008DD459 /* simd_float.h in Headers */,
-				E25D565317E0E0A4008DD459 /* singlecolourfit.h in Headers */,
-				E25D565217E0E0A4008DD459 /* rangefit.h in Headers */,
-				E25D565117E0E0A4008DD459 /* colourfit.h in Headers */,
-				E25D565417E0E0A4008DD459 /* alpha.h in Headers */,
-				E25D565617E0E0A4008DD459 /* config.h in Headers */,
-				E25D565517E0E0A4008DD459 /* colourset.h in Headers */,
-				E25D565717E0E0A4008DD459 /* maths.h in Headers */,
-				E25D565017E0E0A4008DD459 /* colourblock.h in Headers */,
-				E25D564F17E0E0A4008DD459 /* clusterfit.h in Headers */,
-				E25D565A17E0E0A4008DD459 /* simd_ve.h in Headers */,
-				E25D565917E0E0A4008DD459 /* simd_sse.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
 		1AF9A2E9207E468300C87889 /* squish-static */ = {
 			isa = PBXNativeTarget;
@@ -212,7 +164,7 @@
 			buildPhases = (
 				1AF9A2E6207E468300C87889 /* Sources */,
 				1AF9A2E7207E468300C87889 /* Frameworks */,
-				1AF9A2E8207E468300C87889 /* Headers */,
+				E2BF3067232690EF0098A022 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -229,7 +181,7 @@
 			buildPhases = (
 				E25D562117E0E02B008DD459 /* Sources */,
 				E25D562217E0E02B008DD459 /* Frameworks */,
-				E25D562317E0E02B008DD459 /* Headers */,
+				E2BF3065232690120098A022 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/source/DXT/squish-c.cpp
+++ b/source/DXT/squish-c.cpp
@@ -6,7 +6,7 @@
 //
 
 #include "squish-c.h"
-#include "squish.h"
+#include <squish.h>
 
 extern "C" {
 


### PR DESCRIPTION
Avoids unwanted headers in Xcode archives.

Library headers for squish and snappy are copied to folders in the build destination, and this folder is added to the header search paths for HapInAVFoundation. The library headers are correctly omitted from the resulting Xcode archive.

Follows current Apple advice: "Headers build phases do not work correctly with static library targets when archiving in Xcode. Delete this phase, add a Copy Files build phase to your library, and use it to export your header files."

https://developer.apple.com/library/archive/technotes/tn2215/_index.html#//apple_ref/doc/uid/DTS40011221-CH1-PROJ