### PR TITLE
PixelFormats: include missing header

### DIFF
--- a/source/PixelFormats.h
+++ b/source/PixelFormats.h
@@ -28,6 +28,8 @@
 #ifndef HapCodec_PixelFormats_h
 #define HapCodec_PixelFormats_h
 
+#include <MacTypes.h>
+
 /*
  S3TC RGB DXT1
  */


### PR DESCRIPTION
the function prototype for `HapCodecRegisterDXTPixelFormat` contains types
mac-specific types without including the corresponding header. this causes
compile failures when prefix headers are disabled