### PR TITLE
Feat : Metal Player for Test App

### DIFF
--- a/HapInAVF Test App/Base.lproj/MainMenu.xib
+++ b/HapInAVF Test App/Base.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
             <connections>
                 <outlet property="glView" destination="31I-59-1lg" id="vVW-AH-0vN"/>
                 <outlet property="imgView" destination="0yA-2Z-CCI" id="8hU-jI-25O"/>
+                <outlet property="metalView" destination="6om-VZ-axy" id="l6U-f2-k0s"/>
                 <outlet property="statusField" destination="G7c-WL-ZDS" id="sFI-8j-MNj"/>
                 <outlet property="tabView" destination="onX-rk-MSh" id="vjk-m5-tla"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
@@ -670,7 +671,7 @@
                 </menuItem>
             </items>
         </menu>
-        <window title="HapInAVF Test App" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+        <window title="HapInAVF Test App" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" topStrut="YES"/>
             <rect key="contentRect" x="77" y="538" width="400" height="380"/>
@@ -716,6 +717,18 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="pdj-Vy-E1N"/>
                                         </imageView>
+                                    </subviews>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Metal (GPU)" identifier="" id="CwH-8H-CAg">
+                                <view key="view" id="iAH-a6-HRZ">
+                                    <rect key="frame" x="10" y="33" width="354" height="260"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <customView id="6om-VZ-axy" customClass="MetalImageView">
+                                            <rect key="frame" x="17" y="17" width="320" height="240"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        </customView>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/HapInAVF Test App/HapInAVFTestAppDelegate.h
+++ b/HapInAVF Test App/HapInAVFTestAppDelegate.h
@@ -4,6 +4,8 @@
 #import <HapInAVFoundation/HapInAVFoundation.h>
 #import "GLView.h"
 #import "HapPixelBufferTexture.h"
+#import "MetalImageView.h"
+#import "MetalHapDisplayer.h"
 
 
 
@@ -26,6 +28,9 @@
 	
 	HapPixelBufferTexture		*hapTexture;	//	this class uploads the DXT data in a decoded instance of HapDecoderFrame into a GL texture.  this is also where the shader that draws YCoCg DXT data as RGB is loaded.  this class was copied from the hap/quicktime sample app
 	AVPlayerItemHapDXTOutput	*hapOutput;	//	works similarly to "nativeAVFOutput"- it's a subclass of AVPlayerItemOutput, you add it to a player item and ask it for new frames (instances of HapDecoderFrame)
+
+    IBOutlet MetalImageView     *metalView;
+    MetalHapDisplayer           *metalHapDisplayer;
 }
 
 - (void) loadFileAtPath:(NSString *)n;

--- a/HapInAVF Test App/Metal/HapMetalPixelBufferTexture.h
+++ b/HapInAVF Test App/Metal/HapMetalPixelBufferTexture.h
@@ -1,0 +1,29 @@
+#import <Foundation/Foundation.h>
+#import <CoreVideo/CoreVideo.h>
+#import <HapInAVFoundation/HapInAVFoundation.h>
+#import <Metal/Metal.h>
+
+/**
+ A class to maintain a DXT-compressed texture for upload of DXT frames from CoreVideo pixel-buffers.
+ Scaled YCoCg DXT5 requires a shader to convert color values when it is drawn.
+ */
+@interface HapMetalPixelBufferTexture : NSObject
+{
+@private
+    id<MTLDevice> device;
+    id<MTLTexture> textureLayerOne;
+    id<MTLTexture> textureLayerTwo;
+    HapDecoderFrame *decodedFrame;
+    BOOL frameValid;
+}
+
+- (id)initWithDevice:(id<MTLDevice>)device;
+- (void)setDecodedFrame:(HapDecoderFrame*)newFrame onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer;
+- (id<MTLFunction>)fragmentForFrame;
+
+@property (retain, readonly) HapDecoderFrame *decodedFrame;
+@property (readonly) int textureCount;
+@property (readonly) NSArray<id<MTLTexture>> *texturesArray;
+@property (readonly) BOOL srgb;
+
+@end

--- a/HapInAVF Test App/Metal/HapMetalPixelBufferTexture.m
+++ b/HapInAVF Test App/Metal/HapMetalPixelBufferTexture.m
@@ -1,0 +1,302 @@
+#import "HapMetalPixelBufferTexture.h"
+#import <HapInAVFoundation/HapInAVFoundation.h>
+#import "MetalShaderTypes.h"
+#define FourCCLog(n,f) NSLog(@"%@, %c%c%c%c",n,(int)((f>>24)&0xFF),(int)((f>>16)&0xFF),(int)((f>>8)&0xFF),(int)((f>>0)&0xFF))
+
+
+@implementation HapMetalPixelBufferTexture
+{
+    id<MTLFunction> fragmentFunctionScaledCoCgYToRGBA;
+    id<MTLFunction> fragmentFunctionScaledCoCgYPlusAToRGBA;
+    id<MTLFunction> fragmentFunctionDefault;
+    BOOL _srgb;
+}
+
+- (id)initWithDevice:(id<MTLDevice>)theDevice
+{
+    self = [super init];
+    if( self )
+    {
+        device = theDevice;
+        textureLayerOne = nil;
+        textureLayerTwo = nil;
+        decodedFrame = nil;
+        frameValid = NO;
+        id<MTLLibrary> defaultLibrary = [device newDefaultLibrary];
+        fragmentFunctionScaledCoCgYToRGBA = [defaultLibrary newFunctionWithName:@"textureToScreenSamplingShader_ScaledCoCgYToRGBA"];
+        fragmentFunctionScaledCoCgYPlusAToRGBA = [defaultLibrary newFunctionWithName:@"textureToScreenSamplingShader_ScaledCoCgYPlusAToRGBA"];
+        fragmentFunctionDefault = [defaultLibrary newFunctionWithName:@"textureToScreenSamplingShader"];
+    }
+    return self;
+}
+
+- (void)updateIsSrgbForTexturePixelFormat:(MTLPixelFormat)mtlPixelFormat
+{
+    switch( mtlPixelFormat )
+    {
+        case MTLPixelFormatBC1_RGBA_sRGB:
+            _srgb = YES;
+            break;
+        case MTLPixelFormatBC3_RGBA:
+            _srgb = NO;
+            break;
+        case MTLPixelFormatBC4_RUnorm:
+            _srgb = NO;
+            break;
+        default:
+            NSLog(@"issrgb default case not expected: %lu", mtlPixelFormat);
+            _srgb = NO;
+    }
+}
+
+- (MTLPixelFormat)convertToMetalPixelFormat:(int)hapTextureFormat
+{
+    /*
+     Metal equivalents
+     // S3TC/DXT
+     BC1_RGBA = 130,
+     BC1_RGBA_sRGB = 131,
+     BC2_RGBA = 132,
+     BC2_RGBA_sRGB = 133,
+     BC3_RGBA = 134,
+     BC3_RGBA_sRGB = 135,
+     
+     // RGTC
+     BC4_RUnorm = 140,
+     BC4_RSnorm = 141,
+     BC5_RGUnorm = 142,
+     BC5_RGSnorm = 143,
+     */
+    switch( hapTextureFormat )
+    {
+        case HapTextureFormat_RGB_DXT1:
+            return MTLPixelFormatBC1_RGBA_sRGB;
+        case HapTextureFormat_RGBA_DXT5:
+            return MTLPixelFormatBC3_RGBA;
+        case HapTextureFormat_YCoCg_DXT5:
+            return MTLPixelFormatBC3_RGBA;
+        case HapTextureFormat_A_RGTC1:
+            return MTLPixelFormatBC4_RUnorm;
+        default:
+            NSLog(@"unhandled case, expect crash soon: %i", hapTextureFormat);
+            return MTLPixelFormatBGRA8Unorm;
+    }
+}
+
+- (void)dealloc
+{
+    textureLayerOne = nil;
+    textureLayerTwo = nil;
+    if( decodedFrame != nil )
+    {
+        [decodedFrame release];
+        decodedFrame = nil;
+    }
+    [super dealloc];
+}
+
+- (id<MTLTexture>)createTextureWithFormat:(MTLPixelFormat)format width:(int)width height:(int)height
+{
+    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:format
+                                                                                                 width:width
+                                                                                                height:height
+                                                                                             mipmapped:NO];
+    textureDescriptor.usage = MTLTextureUsageShaderRead;
+    textureDescriptor.storageMode = MTLStorageModeManaged;
+    const id<MTLTexture> newTexture = [device newTextureWithDescriptor:textureDescriptor];
+    return newTexture;
+}
+
+- (id<MTLTexture>)textureForIndex:(int)index
+{
+    if( index==0 )
+    {
+        return textureLayerOne;
+    }
+    else if( index==1 )
+    {
+        return textureLayerTwo;
+    }
+    else
+    {
+        return nil;
+    }
+}
+
+// Must happen inside an initialised commandBuffer
+- (void)setDecodedFrame:(HapDecoderFrame *)newFrame onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer
+{
+    [newFrame retain];
+    [decodedFrame release];
+    decodedFrame = newFrame;
+    frameValid = NO;
+    
+    if( decodedFrame == NULL )
+    {
+        NSLog(@"\t\terr: decodedFrame nil, bailing. %s",__func__);
+        return;
+    }
+    
+    const NSSize tmpSize = [decodedFrame dxtImgSize];
+    const int roundedWidth = tmpSize.width;
+    const int roundedHeight = tmpSize.height;
+    
+    if( roundedWidth % 4 != 0 || roundedHeight % 4 != 0 )
+    {
+        NSLog(@"\t\terr: width isn't a multiple of 4, bailing. %s",__func__);
+        return;
+    }
+    
+    const int textureCount = [decodedFrame dxtPlaneCount];
+    OSType *dxtPixelFormats = [decodedFrame dxtPixelFormats];
+    MTLPixelFormat newInternalFormat;
+    size_t *dxtDataSizes = [decodedFrame dxtDataSizes];
+    void **dxtBaseAddresses = [decodedFrame dxtDatas];
+    
+    for( int texIndex=0; texIndex<textureCount; ++texIndex )
+    {
+        unsigned int bitsPerPixel = 0;
+        switch( dxtPixelFormats[texIndex] )
+        {
+            case kHapCVPixelFormat_RGB_DXT1:
+                newInternalFormat = [self convertToMetalPixelFormat:HapTextureFormat_RGB_DXT1];
+                bitsPerPixel = 4;
+                break;
+            case kHapCVPixelFormat_RGBA_DXT5:
+            case kHapCVPixelFormat_YCoCg_DXT5:
+                newInternalFormat = [self convertToMetalPixelFormat:HapTextureFormat_RGBA_DXT5];
+                bitsPerPixel = 8;
+                break;
+            case kHapCVPixelFormat_CoCgXY:
+                if( texIndex==0 )
+                {
+                    newInternalFormat = [self convertToMetalPixelFormat:HapTextureFormat_RGBA_DXT5];
+                    bitsPerPixel = 8;
+                }
+                else
+                {
+                    newInternalFormat = [self convertToMetalPixelFormat:HapTextureFormat_A_RGTC1];
+                    bitsPerPixel = 4;
+                }
+                break;
+            case kHapCVPixelFormat_YCoCg_DXT5_A_RGTC1:
+                if( texIndex==0 )
+                {
+                    newInternalFormat = [self convertToMetalPixelFormat:HapTextureFormat_RGBA_DXT5];
+                    bitsPerPixel = 8;
+                }
+                else
+                {
+                    newInternalFormat = [self convertToMetalPixelFormat:HapTextureFormat_A_RGTC1];
+                    bitsPerPixel = 4;
+                }
+                break;
+            case kHapCVPixelFormat_A_RGTC1:
+                newInternalFormat = [self convertToMetalPixelFormat:HapTextureFormat_A_RGTC1];
+                bitsPerPixel = 4;
+                break;
+            default:
+                // we don't support non-DXT pixel buffers
+                NSLog(@"\t\terr: unrecognized pixel format (%X) at index %d in %s",dxtPixelFormats[texIndex],texIndex,__func__);
+                FourCCLog(@"\t\tpixel format fourcc is",dxtPixelFormats[texIndex]);
+                frameValid = NO;
+                return;
+                break;
+        }
+        
+        [self updateIsSrgbForTexturePixelFormat:newInternalFormat];
+        
+        const int bytesPerRow = (roundedWidth * bitsPerPixel) / 8;
+        const GLsizei newDataLength = (int)(bytesPerRow * roundedHeight);
+        const size_t actualBufferSize = dxtDataSizes[texIndex];
+        
+        // make sure the buffer's at least as big as necessary
+        if( actualBufferSize < newDataLength )
+        {
+            NSLog(@"\t\terr: new data length incorrect, %d vs %ld in %s",newDataLength,actualBufferSize,__func__);
+            frameValid = NO;
+            return;
+        }
+        frameValid = YES;
+        
+        GLvoid *baseAddress = dxtBaseAddresses[texIndex];
+        
+        // Lazy texture creation & update
+        if( [self textureForIndex:texIndex] == nil ||
+           roundedWidth != [self textureForIndex:texIndex].width ||
+           roundedHeight != [self textureForIndex:texIndex].height ||
+           newInternalFormat != [self textureForIndex:texIndex].pixelFormat )
+        {
+            id<MTLTexture> newTexture = [self createTextureWithFormat:newInternalFormat width:roundedWidth height:roundedHeight];
+            newTexture.label = [NSString stringWithFormat:@"Hap Texture index %i", texIndex];
+            if( texIndex==0 )
+            {
+                textureLayerOne = newTexture;
+            }
+            else if( texIndex==1 )
+            {
+                textureLayerTwo = newTexture;
+            }
+            else
+            {
+                NSLog(@"ERR: Index should be 1 or 2. Got %i.", texIndex);
+                @throw NSInternalInconsistencyException;
+            }
+        }
+        
+#warning MTO: this *4 is unexpected, but it works
+        const int workingBytesPerRow = bytesPerRow*4;
+        MTLRegion region = MTLRegionMake2D(0, 0, roundedWidth, roundedHeight);
+        [[self textureForIndex:texIndex] replaceRegion:region mipmapLevel:0 withBytes:baseAddress bytesPerRow:workingBytesPerRow];
+    }
+}
+
+- (HapDecoderFrame *)decodedFrame
+{
+    return decodedFrame;
+}
+
+- (int)textureCount
+{
+    return [decodedFrame dxtPlaneCount];
+}
+
+- (NSArray<id<MTLTexture>>*)texturesArray
+{
+    if( textureLayerTwo != nil )
+    {
+        return @[textureLayerOne, textureLayerTwo];
+    }
+    else
+    {
+        return @[textureLayerOne];
+    }
+}
+
+- (id<MTLFunction>)fragmentForFrame
+{
+    if( frameValid && decodedFrame!=nil )
+    {
+        OSType codecSubType = [decodedFrame codecSubType];
+        if( codecSubType==kHapYCoCgCodecSubType )
+        {
+            return fragmentFunctionScaledCoCgYToRGBA;
+        }
+        else if( codecSubType == kHapYCoCgACodecSubType )
+        {
+            return fragmentFunctionScaledCoCgYPlusAToRGBA;
+        }
+        // rgb
+        else
+        {
+            return fragmentFunctionDefault;
+        }
+    }
+    else
+    {
+        NSLog(@"unexpected invalid frame");
+        return fragmentFunctionDefault;
+    }
+}
+
+@end

--- a/HapInAVF Test App/Metal/MetalHapDisplayer.h
+++ b/HapInAVF Test App/Metal/MetalHapDisplayer.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#import <HapInAVFoundation/HapInAVFoundation.h>
+#import "MetalImageView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MetalHapDisplayer : NSObject
+
+- (void)displayFrame:(HapDecoderFrame*)dxtFrame inView:(MetalImageView*)metalView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/HapInAVF Test App/Metal/MetalHapDisplayer.m
+++ b/HapInAVF Test App/Metal/MetalHapDisplayer.m
@@ -1,0 +1,94 @@
+#import "MetalHapDisplayer.h"
+#import "TextureRenderer.h"
+#import "HapMetalPixelBufferTexture.h"
+
+@implementation MetalHapDisplayer
+{
+    HapMetalPixelBufferTexture *pixelBufferTexture;
+    TextureRenderer *textureRenderer;
+    MTLPixelFormat pixelFormat;
+    id<MTLCommandQueue> commandQueue;
+    id<MTLDevice> device;
+    id<MTLTexture> visualisationTexture;
+}
+
+- (void)displayFrame:(HapDecoderFrame*)dxtFrame inView:(MetalImageView*)view
+{
+    // Lazy Inits & updates
+    NSSize frameSize = [dxtFrame imgSize];
+    if( device != view.device || commandQueue == nil || pixelBufferTexture == nil )
+    {
+        NSLog(@"lazy init steady ressources");
+        device = view.device;
+        commandQueue = [device newCommandQueue];
+        pixelBufferTexture = [[HapMetalPixelBufferTexture alloc] initWithDevice:device];
+        pixelFormat = view.colorPixelFormat;
+    }
+    
+    
+    /// RENDER
+    const id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
+    commandBuffer.label = @"Metal Decode HAP Command Buffer";
+    [pixelBufferTexture setDecodedFrame:dxtFrame onCommandBuffer:commandBuffer];
+    
+    const id<MTLFunction> fragmentForFrame = [pixelBufferTexture fragmentForFrame];
+    // last minute textureRenderer lazy init
+    if( view.srgb != pixelBufferTexture.srgb )
+    {
+        view.srgb = pixelBufferTexture.srgb;
+        visualisationTexture = [self createTextureForDevice:device width:frameSize.width height:frameSize.height pixelFormat:pixelFormat];
+    }
+    
+    const int numberOfTexturesInFrame = pixelBufferTexture.textureCount;
+    
+    if( visualisationTexture == nil || frameSize.width != visualisationTexture.width || frameSize.height != frameSize.height )
+    {
+        NSLog(@"lazy init visualisation texture (volatile)");
+        visualisationTexture = [self createTextureForDevice:device width:frameSize.width height:frameSize.height pixelFormat:pixelFormat];
+    }
+    if( textureRenderer == nil || textureRenderer.fragment != fragmentForFrame )
+    {
+        NSLog(@"lazy init textureRenderer (volatile)");
+        textureRenderer = [[TextureRenderer alloc] initWithDevice:device colorPixelFormat:pixelFormat customFragment:fragmentForFrame numberOfExtraColorAttachments:numberOfTexturesInFrame-1];
+    }
+    
+    const id<MTLTexture> textureToRender = [pixelBufferTexture.texturesArray objectAtIndex:0];
+    if( numberOfTexturesInFrame == 1 )
+    {
+        [textureRenderer renderFromTexture:textureToRender inTexture:visualisationTexture onCommandBuffer:commandBuffer];
+    }
+    else if( numberOfTexturesInFrame == 2 )
+    {
+        [textureRenderer renderFromTexture:textureToRender extraColorAttachements:@[[pixelBufferTexture.texturesArray objectAtIndex:1]] inTexture:visualisationTexture onCommandBuffer:commandBuffer];
+    }
+    else
+    {
+        NSLog(@"this is unexpected");
+        return;
+    }
+    
+    [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> _Nonnull _)
+     {
+         view.image = visualisationTexture;
+         [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+             [view setNeedsDisplay:YES];
+         }];
+     }];
+    [commandBuffer commit];
+}
+
+#pragma mark Pure utils
+
+- (id<MTLTexture>)createTextureForDevice:(id<MTLDevice>)theDevice width:(int)width height:(int)height pixelFormat:(MTLPixelFormat)thePixelFormat
+{
+    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:thePixelFormat
+                                                                                                 width:width
+                                                                                                height:height
+                                                                                             mipmapped:NO];
+    textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+    textureDescriptor.storageMode = MTLStorageModePrivate; // GPU only for better performance
+    id<MTLTexture> texture = [theDevice newTextureWithDescriptor:textureDescriptor];
+    return texture;
+}
+
+@end

--- a/HapInAVF Test App/Metal/MetalImageView.h
+++ b/HapInAVF Test App/Metal/MetalImageView.h
@@ -1,0 +1,16 @@
+#import <Cocoa/Cocoa.h>
+#import <MetalKit/MTKView.h>
+
+@interface MetalImageView : MTKView
+
+@property (readwrite, assign) id<MTLTexture> image;
+// Returns the dimensions the view will render at, including any adjustment for a high-resolution display
+@property (readonly, nonatomic) NSSize renderSize;
+@property (readwrite, nonatomic) BOOL srgb;
+@property (readwrite, nonatomic) BOOL needsReshape;
+@property (readwrite, nonatomic) BOOL flip;
+
+// Uses a blit of the image provided
+- (void)setUnsafeImage:(id<MTLTexture>)unsafeImage;
+
+@end

--- a/HapInAVF Test App/Metal/MetalImageView.m
+++ b/HapInAVF Test App/Metal/MetalImageView.m
@@ -1,0 +1,168 @@
+#import "MetalImageView.h"
+#import "TextureRenderer.h"
+
+
+@implementation MetalImageView
+{
+    id<MTLTexture> _image;
+    BOOL _needsReshape;
+    BOOL _srgb;
+    BOOL _flip;
+    TextureRenderer *textureRenderer;
+    id<MTLCommandQueue> commandQueue;
+    id<MTLTexture> threadSafeImage;
+}
+
+- (void)awakeFromNib
+{
+    self.device = MTLCreateSystemDefaultDevice();
+    [self initRenderingRessources];
+    commandQueue = [self.device newCommandQueue];
+    self.flip = NO;
+}
+
+- (void)initRenderingRessources
+{
+    self.colorPixelFormat = self.srgb ? MTLPixelFormatBGRA8Unorm_sRGB : MTLPixelFormatBGRA8Unorm;
+    textureRenderer = [[TextureRenderer alloc] initWithDevice:self.device colorPixelFormat:self.colorPixelFormat];
+    textureRenderer.flip = self.flip;
+    textureRenderer.clearColor = MTLClearColorMake(1, 0, 0, 1);
+}
+
+- (void)dealloc
+{
+    _image = nil;
+    [super dealloc];
+}
+
+// Disable internal timer clock with these two methods
+- (BOOL)enableSetNeedsDisplay
+{
+    return YES;
+}
+- (BOOL)isPaused
+{
+    return YES;
+}
+
+- (NSSize)renderSize
+{
+    if( [NSView instancesRespondToSelector:@selector(convertRectToBacking:)] )
+    {
+        // 10.7+
+        return [self convertSizeToBacking:[self bounds].size];
+    }
+    else return [self bounds].size;
+}
+
+- (MTLViewport)viewportForFrameWidth:(int)frameWidth frameHeight:(int)frameHeight viewWidth:(int)viewWidth viewHeight:(int)viewHeight
+{
+    const float frameRatio = (float)frameWidth / (float)frameHeight;
+    const float viewportRatio = (float)viewWidth / (float)viewHeight;
+    
+    // If view ratio bigger = wider = black bars on left/right = maximum height and centered width
+    if( frameRatio < viewportRatio )
+    {
+        const int allowedWidthForRatio = frameRatio * viewHeight;
+        const float freeWidthSpace = (viewWidth - allowedWidthForRatio);
+        return (MTLViewport){freeWidthSpace, 0.0, (viewWidth-freeWidthSpace)*2, viewHeight*2, -1.0, 1.0 };
+    }
+    // if view ratio smaller = taller = black bars on top/bottom = maximum width and centered height
+    else if ( viewportRatio < frameRatio )
+    {
+        const float allowedHeightForRatio = viewWidth / frameRatio;
+        const float freeHeightSpace = (viewHeight - allowedHeightForRatio);
+        return (MTLViewport){0.0, freeHeightSpace, viewWidth*2, (viewHeight-freeHeightSpace)*2, -1.0, 1.0 };
+    }
+    // perfect equality
+    else
+    {
+        return (MTLViewport) {0.0, 0.0, viewWidth*2, viewHeight*2, -1.0, 1.0 };
+    }
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+    @autoreleasepool
+    {
+        if( !self.currentDrawable.texture )
+        {
+            NSLog(@"WARN: current drawable is not available. skip frame render.");
+            return;
+        }
+        
+        // If there's a valid render pass descriptor, use it to render to the current drawable.
+        if( _image != nil )
+        {
+            const id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
+            const MTLViewport viewport = [self viewportForFrameWidth:(int)_image.width frameHeight:(int)_image.height viewWidth:self.bounds.size.width viewHeight:self.bounds.size.height];
+            [textureRenderer renderFromTexture:_image inTexture:self.currentDrawable.texture onCommandBuffer:commandBuffer andViewport:viewport];
+            // Register the drawable's presentation.
+            [commandBuffer presentDrawable:self.currentDrawable];
+            // Finalize your onscreen CPU work and commit the command buffer to a GPU.
+            [commandBuffer commit];
+            [commandBuffer waitUntilCompleted];
+        }
+    }
+}
+
+- (void)setUnsafeImage:(id<MTLTexture>)unsafeImage
+{
+    // A thread safe texture is lazy initialized and re-used, making the assumption that if won't change often
+    // Note: this optimisation won't work properly if multiple actors tries to use it in different render loops
+    if( threadSafeImage == nil || threadSafeImage.pixelFormat != unsafeImage.pixelFormat || threadSafeImage.width != unsafeImage.width || threadSafeImage.height != unsafeImage.height )
+    {
+        NSLog(@"lazy thread safe image init");
+        MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:unsafeImage.pixelFormat
+                                                                                                     width:unsafeImage.width
+                                                                                                    height:unsafeImage.height
+                                                                                                 mipmapped:NO];
+        textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+        textureDescriptor.storageMode = MTLStorageModePrivate; // GPU only for better performance
+        threadSafeImage = [self.device newTextureWithDescriptor:textureDescriptor];
+    }
+    
+    const id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
+    const id<MTLBlitCommandEncoder> blitCommandEncoder = [commandBuffer blitCommandEncoder];
+    blitCommandEncoder.label = @"MetalImageView setUnsafeImage Blit Command Encoder";
+    [blitCommandEncoder copyFromTexture:unsafeImage sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(unsafeImage.width, unsafeImage.height, 1) toTexture:threadSafeImage destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
+    [blitCommandEncoder endEncoding];
+    [commandBuffer commit];
+    [commandBuffer waitUntilCompleted];
+    self.image = threadSafeImage;
+}
+
+
+- (void)setSrgb:(BOOL)srgb
+{
+    _srgb = srgb;
+#warning MTO: workaround to keep KVO in main thread
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        [self willChangeValueForKey:@"srgb"];
+        [self didChangeValueForKey:@"srgb"];
+    }];
+    [self initRenderingRessources];
+}
+
+- (BOOL)srgb
+{
+    return _srgb;
+}
+
+- (void)setFlip:(BOOL)flip
+{
+    _flip = flip;
+#warning MTO: workaround to keep KVO in main thread
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        [self willChangeValueForKey:@"flip"];
+        [self didChangeValueForKey:@"flip"];
+    }];
+    textureRenderer.flip = flip;
+}
+
+- (BOOL)flip
+{
+    return _flip;
+}
+
+@end

--- a/HapInAVF Test App/Metal/MetalShaderTypes.h
+++ b/HapInAVF Test App/Metal/MetalShaderTypes.h
@@ -1,0 +1,45 @@
+#ifndef MetalShaderTypes_h
+#define MetalShaderTypes_h
+
+#include <simd/simd.h>
+
+// Buffer index values shared between shader and C code to ensure Metal shader buffer inputs match
+//   Metal API buffer set calls
+typedef enum AAPLVertexInputIndex
+{
+    AAPLVertexInputIndexVertices     = 0,
+    AAPLVertexInputIndexViewportSize =  1,
+} AAPLVertexInputIndex;
+
+// Texture index values shared between shader and C code to ensure Metal shader buffer inputs match
+//   Metal API texture set calls
+typedef enum AAPLTextureIndex
+{
+    AAPLTextureIndexZero = 0,
+    AAPLTextureIndexOne = 1,
+    AAPLTextureIndexTwo = 2,
+    AAPLTextureIndexThree = 3,
+} AAPLTextureIndex;
+
+//  This structure defines the layout of each vertex in the array of vertices set as an input to our
+//    Metal vertex shader.  Since this header is shared between our .metal shader and C code,
+//    we can be sure that the layout of the vertex array in the Ccode matches the layour that
+//    our vertex shader expects
+typedef struct
+{
+    //  Positions in pixel space (i.e. a value of 100 indicates 100 pixels from the origin/center)
+    vector_float2 position;
+    // Floating point RGBA colors
+    vector_float4 color;
+} AAPLColorVertex;
+
+typedef struct
+{
+    // Positions in pixel space (i.e. a value of 100 indicates 100 pixels from the origin/center)
+    vector_float2 position;
+    
+    // 2D texture coordinate
+    vector_float2 textureCoordinate;
+} AAPLTextureVertex;
+
+#endif /* MetalShaderTypes_h */

--- a/HapInAVF Test App/Metal/Shaders.metal
+++ b/HapInAVF Test App/Metal/Shaders.metal
@@ -1,0 +1,114 @@
+#include <metal_stdlib>
+using namespace metal;
+
+#include "MetalShaderTypes.h"
+
+// Vertex shader outputs and fragmentShader inputs.
+typedef struct
+{
+    // The [[position]] attribute qualifier of this member indicates this value is the clip space
+    //   position of the vertex when this structure is returned from the vertex function
+    float4 clipSpacePosition [[position]];
+    
+    // Since this member does not have a special attribute qualifier, the rasterizer will
+    //   interpolate its value with values of other vertices making up the triangle and
+    //   pass that interpolated value to the fragment shader for each fragment in that triangle
+    float4 color;
+    
+    // Since this member does not have a special attribute qualifier, the rasterizer will
+    //   interpolate its value with values of other vertices making up the triangle and
+    //   pass that interpolated value to the fragment shader for each fragment in that triangle;
+    float2 textureCoordinate;
+    
+} RasterizerData;
+
+
+
+#pragma mark basic Vertex
+vertex RasterizerData
+textureToScreenVertexShader(uint vertexID [[ vertex_id ]],
+                            constant AAPLTextureVertex *vertexArray [[ buffer(AAPLVertexInputIndexVertices) ]],
+                            constant vector_uint2 *viewportSizePointer [[ buffer(AAPLVertexInputIndexViewportSize) ]])
+{
+    
+    RasterizerData out;
+    
+    // Index into our array of positions to get the current vertex
+    //   Our positions are specified in pixel dimensions (i.e. a value of 100 is 100 pixels from
+    //   the origin)
+    float2 pixelSpacePosition = vertexArray[vertexID].position.xy;
+    
+    // Get the size of the drawable so that we can convert to normalized device coordinates,
+    float2 viewportSize = float2(*viewportSizePointer);
+    
+    // The output position of every vertex shader is in clip space (also known as normalized device
+    //   coordinate space, or NDC). A value of (-1.0, -1.0) in clip-space represents the
+    //   lower-left corner of the viewport whereas (1.0, 1.0) represents the upper-right corner of
+    //   the viewport.
+    
+    // In order to convert from positions in pixel space to positions in clip space we divide the
+    //   pixel coordinates by half the size of the viewport.
+    out.clipSpacePosition.xy = pixelSpacePosition / (viewportSize / 2.0);
+    
+    // Set the z component of our clip space position 0 (since we're only rendering in
+    //   2-Dimensions for this sample)
+    out.clipSpacePosition.z = 0.0;
+    
+    // Set the w component to 1.0 since we don't need a perspective divide, which is also not
+    //   necessary when rendering in 2-Dimensions
+    out.clipSpacePosition.w = 1.0;
+    
+    // Pass our input textureCoordinate straight to our output RasterizerData. This value will be
+    //   interpolated with the other textureCoordinate values in the vertices that make up the
+    //   triangle.
+    out.textureCoordinate = vertexArray[vertexID].textureCoordinate;
+    
+    return out;
+}
+
+#pragma mark basic Fragment
+fragment float4
+textureToScreenSamplingShader(RasterizerData in [[stage_in]],
+                              texture2d<half> colorTexture [[ texture(AAPLTextureIndexZero) ]])
+{
+    constexpr sampler textureSampler (mag_filter::linear, min_filter::linear);
+    // Sample the texture to obtain a color
+    const half4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+    // We return the color of the texture
+    return float4(colorSample);
+}
+
+#pragma mark HAP color conversion
+float3 CoCgSYToRgb(const float4 CoCgSY)
+{
+    const float4 offsets = float4(-0.50196078431373, -0.50196078431373, 0.0, 0.0);
+    const float4 CoCgSYOffseted = CoCgSY + offsets;
+    const float scale = ( CoCgSYOffseted.z * ( 255.0 / 8.0 ) ) + 1.0;
+    const float Co = CoCgSYOffseted.x / scale;
+    const float Cg = CoCgSYOffseted.y / scale;
+    const float Y = CoCgSYOffseted.w;
+    const float3 rgb = float3(Y + Co - Cg, Y + Cg, Y - Co - Cg);
+    return rgb;
+}
+
+fragment float4
+textureToScreenSamplingShader_ScaledCoCgYToRGBA(RasterizerData in [[stage_in]],
+                                                texture2d<float> colorTexture [[ texture(AAPLTextureIndexZero) ]])
+{
+    constexpr sampler textureSampler (mag_filter::linear, min_filter::linear);
+    const float4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+    const float3 rgb = CoCgSYToRgb(colorSample);
+    return float4(rgb, 1.);
+}
+
+fragment float4
+textureToScreenSamplingShader_ScaledCoCgYPlusAToRGBA(RasterizerData in [[stage_in]],
+                                                     texture2d<float> colorTexture [[ texture(AAPLTextureIndexZero) ]],
+                                                     texture2d<float> maskTexture [[ texture(AAPLTextureIndexOne) ]])
+{
+    constexpr sampler textureSampler (mag_filter::linear, min_filter::linear);
+    const float4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+    const float4 maskSample = maskTexture.sample(textureSampler, in.textureCoordinate);
+    const float3 rgb = CoCgSYToRgb(colorSample);
+    return float4(rgb, maskSample.x);
+}

--- a/HapInAVF Test App/Metal/TextureRenderer.h
+++ b/HapInAVF Test App/Metal/TextureRenderer.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+@import Metal;
+
+@interface TextureRenderer : NSObject
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device colorPixelFormat:(MTLPixelFormat)colorPixelFormat;
+- (instancetype)initWithDevice:(id<MTLDevice>)device colorPixelFormat:(MTLPixelFormat)colorPixelFormat customFragment:(id<MTLFunction>)customFragment numberOfExtraColorAttachments:(int)numberOfExtraColorAttachments;
+
+- (void)renderFromTexture:(id<MTLTexture>)offScreenTexture inTexture:(id<MTLTexture>)texture onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer;
+- (void)renderFromTexture:(id<MTLTexture>)offScreenTexture inTexture:(id<MTLTexture>)texture onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer andViewport:(MTLViewport)viewport;
+- (void)renderFromTexture:(id<MTLTexture>)offScreenTexture extraColorAttachements:(NSArray<id<MTLTexture>>*)extraTextures inTexture:(id<MTLTexture>)texture onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer;
+
+@property (readwrite) bool flip;
+@property (readonly) id<MTLFunction> fragment;
+@property (readwrite, nonatomic) MTLClearColor clearColor;
+
+@end
+

--- a/HapInAVF Test App/Metal/TextureRenderer.m
+++ b/HapInAVF Test App/Metal/TextureRenderer.m
@@ -1,0 +1,153 @@
+#import "TextureRenderer.h"
+#import "MetalShaderTypes.h"
+
+@implementation TextureRenderer
+{
+    vector_uint2 _viewportSize;
+    id<MTLRenderPipelineState> pipeline;
+    int numberOfExtraColorAttachements;
+}
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device colorPixelFormat:(MTLPixelFormat)colorPixelFormat
+{
+    id<MTLLibrary> defaultLibrary = [device newDefaultLibrary];
+    return [self initWithDevice:device colorPixelFormat:colorPixelFormat
+                 customFragment:[defaultLibrary newFunctionWithName:@"textureToScreenSamplingShader"]
+  numberOfExtraColorAttachments:0];
+}
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device colorPixelFormat:(MTLPixelFormat)colorPixelFormat customFragment:(id<MTLFunction>)customFragment numberOfExtraColorAttachments:(int)theNumberOfExtraColorAttachments
+{
+    self = [super init];
+    if( self )
+    {
+        numberOfExtraColorAttachements = theNumberOfExtraColorAttachments;
+        NSError *error = NULL;
+        id<MTLLibrary> defaultLibrary = [device newDefaultLibrary];
+        
+        // Load the vertex/fragment functions from the library
+        id <MTLFunction> vertexFunction = [defaultLibrary newFunctionWithName:@"textureToScreenVertexShader"];
+        [self willChangeValueForKey:@"fragment"];
+        _fragment = customFragment;
+        [self didChangeValueForKey:@"fragment"];
+        
+        // Set up a descriptor for creating a pipeline state object
+        MTLRenderPipelineDescriptor *pipelineStateDescriptor = [[MTLRenderPipelineDescriptor alloc] init];
+        pipelineStateDescriptor.label = @"Texture Renderer Pipeline State Descriptor";
+        pipelineStateDescriptor.vertexFunction = vertexFunction;
+        pipelineStateDescriptor.fragmentFunction = self.fragment;
+        pipelineStateDescriptor.colorAttachments[0].pixelFormat = colorPixelFormat;
+        
+        // HAP Blending
+        /// (1-videoRGB)*BackRGB + (1)*VideoRGB
+        /// (1-videoAlphaAlpha) BackAlpha + (1)*videoAlpha
+        pipelineStateDescriptor.colorAttachments[0].blendingEnabled             = YES;
+        pipelineStateDescriptor.colorAttachments[0].rgbBlendOperation           = MTLBlendOperationAdd;
+        pipelineStateDescriptor.colorAttachments[0].alphaBlendOperation         = MTLBlendOperationAdd;
+        
+        // Video is here
+        pipelineStateDescriptor.colorAttachments[0].sourceRGBBlendFactor        = MTLBlendFactorOne;
+        pipelineStateDescriptor.colorAttachments[0].sourceAlphaBlendFactor      = MTLBlendFactorOne;
+        // Clear color is here
+        pipelineStateDescriptor.colorAttachments[0].destinationRGBBlendFactor   = MTLBlendFactorOneMinusSourceAlpha;
+        pipelineStateDescriptor.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+        
+        pipeline = [device newRenderPipelineStateWithDescriptor:pipelineStateDescriptor error:&error];
+        
+        if( !pipeline )
+        {
+            NSLog(@"Failed to created pipeline state, error %@", error);
+            return nil;
+        }
+        
+        self.flip = NO;
+        self.clearColor = MTLClearColorMake(0, 0, 0, 0);
+    }
+    return self;
+}
+
+- (void)renderFromTexture:(id<MTLTexture>)offScreenTexture inTexture:(id<MTLTexture>)texture onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer
+{
+    const MTLViewport viewport = (MTLViewport){0.0, 0.0, offScreenTexture.width, offScreenTexture.height, -1.0, 1.0 };
+    [self renderFromTexture:offScreenTexture extraColorAttachements:@[] inTexture:texture onCommandBuffer:commandBuffer andViewPort:viewport];
+}
+
+- (void)renderFromTexture:(id<MTLTexture>)offScreenTexture inTexture:(id<MTLTexture>)texture onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer andViewport:(MTLViewport)viewport
+{
+    [self renderFromTexture:offScreenTexture extraColorAttachements:@[] inTexture:texture onCommandBuffer:commandBuffer andViewPort:viewport];
+}
+
+- (void)renderFromTexture:(id<MTLTexture>)offScreenTexture extraColorAttachements:(NSArray<id<MTLTexture>>*)extraTextures inTexture:(id<MTLTexture>)texture onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer
+{
+    const MTLViewport viewport = (MTLViewport){0.0, 0.0, offScreenTexture.width, offScreenTexture.height, -1.0, 1.0 };
+    [self renderFromTexture:offScreenTexture extraColorAttachements:extraTextures inTexture:texture onCommandBuffer:commandBuffer andViewPort:viewport];
+}
+
+- (void)renderFromTexture:(id<MTLTexture>)offScreenTexture extraColorAttachements:(NSArray<id<MTLTexture>>*)extraTextures inTexture:(id<MTLTexture>)texture onCommandBuffer:(id<MTLCommandBuffer>)commandBuffer andViewPort:(MTLViewport)viewport
+{
+    if( extraTextures.count != numberOfExtraColorAttachements )
+    {
+        NSLog(@"Render aborted. Extra textures received:(%lu) should be:(%i)", extraTextures.count, numberOfExtraColorAttachements);
+        return;
+    }
+    if( offScreenTexture == nil )
+    {
+        NSLog(@"Render aborted. offscreen texture is nil");
+        return;
+    }
+    if( texture == nil )
+    {
+        NSLog(@"Render aborted. output texture is nil");
+        return;
+    }
+    
+    _viewportSize.x = viewport.width;
+    _viewportSize.y = viewport.height;
+    
+    const float w = viewport.width/2;
+    const float h = viewport.height/2;
+    const float flipValue = self.flip ? -1 : 1;
+    
+    const AAPLTextureVertex quadVertices[] =
+    {
+        // Pixel positions, Texture coordinates
+        { {  w,   flipValue * h },  { 1.f, 1.f } },
+        { { -w,   flipValue * h },  { 0.f, 1.f } },
+        { { -w,  flipValue * -h },  { 0.f, 0.f } },
+        
+        { {  w,  flipValue * h },  { 1.f, 1.f } },
+        { { -w,  flipValue * -h },  { 0.f, 0.f } },
+        { {  w,  flipValue * -h },  { 1.f, 0.f } },
+    };
+    
+    const NSUInteger numberOfVertices =  sizeof(quadVertices) / sizeof(AAPLTextureVertex);
+    MTLRenderPassDescriptor *renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+    renderPassDescriptor.colorAttachments[0].texture = texture;
+    renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
+    renderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionDontCare;
+    renderPassDescriptor.colorAttachments[0].clearColor = self.clearColor;
+    
+    
+    // Create a render command encoder so we can render into something
+    id <MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
+    renderEncoder.label = @"Texture Renderer Render Encoder";
+    [renderEncoder setViewport:viewport];
+    [renderEncoder setRenderPipelineState:pipeline];
+    [renderEncoder setVertexBytes:quadVertices length:sizeof(quadVertices) atIndex:AAPLVertexInputIndexVertices];
+    [renderEncoder setVertexBytes:&_viewportSize length:sizeof(_viewportSize)atIndex:AAPLVertexInputIndexViewportSize];
+    [renderEncoder setFragmentTexture:offScreenTexture atIndex:AAPLTextureIndexZero];
+    
+    // Insert extra color attachements
+    [extraTextures
+     enumerateObjectsUsingBlock:
+     ^(id<MTLTexture> extraTexture, NSUInteger index, BOOL *stop)
+     {
+#warning MTO: assumption that AAPLTextureIndex enum values & index values are equal
+         [renderEncoder setFragmentTexture:extraTexture atIndex:index+1];
+     }];
+    
+    [renderEncoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:numberOfVertices];
+    [renderEncoder endEncoding];
+}
+
+@end

--- a/HapInAVFoundation.xcodeproj/project.pbxproj
+++ b/HapInAVFoundation.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		1A05185F1A3E17CF00FC80D2 /* HapPixelBufferTexture.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A05185D1A3E17CF00FC80D2 /* HapPixelBufferTexture.m */; };
 		1A0518621A3E17DC00FC80D2 /* HapInAVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A97F5AB1A38ABBF00E0DC74 /* HapInAVFoundation.framework */; };
 		1A0518641A3E17F000FC80D2 /* HapInAVFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1A97F5AB1A38ABBF00E0DC74 /* HapInAVFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		1A0518681A3E1DAB00FC80D2 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A0518671A3E1DAB00FC80D2 /* CoreVideo.framework */; };
 		1A05186B1A3E228700FC80D2 /* ScaledCoCgYToRGBA.frag in Resources */ = {isa = PBXBuildFile; fileRef = 1A0518691A3E228700FC80D2 /* ScaledCoCgYToRGBA.frag */; };
 		1A05186C1A3E228700FC80D2 /* ScaledCoCgYToRGBA.vert in Resources */ = {isa = PBXBuildFile; fileRef = 1A05186A1A3E228700FC80D2 /* ScaledCoCgYToRGBA.vert */; };
 		1A0535FA1A38C9FD005B47BD /* squish-c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A0535F81A38C9FD005B47BD /* squish-c.cpp */; };
@@ -163,6 +162,13 @@
 		1ACF5DEC1A3E4127005DDF19 /* PixelFormats.c in Sources */ = {isa = PBXBuildFile; fileRef = 1ACF5DEB1A3E4127005DDF19 /* PixelFormats.c */; };
 		1ACF5DED1A3E41FF005DDF19 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A0518671A3E1DAB00FC80D2 /* CoreVideo.framework */; };
 		1AE092DC1AFE96F4004E866B /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AE092DB1AFE96F4004E866B /* VideoToolbox.framework */; };
+		840B32C72417D9DD007CA678 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 840B32C62417D9DD007CA678 /* Metal.framework */; };
+		840B32CC2417E796007CA678 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 840B32CB2417E796007CA678 /* MetalKit.framework */; };
+		84C83733242A79B000734A42 /* TextureRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C83726242A79B000734A42 /* TextureRenderer.m */; };
+		84C83734242A79B000734A42 /* MetalImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C83728242A79B000734A42 /* MetalImageView.m */; };
+		84C83736242A79B000734A42 /* HapMetalPixelBufferTexture.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C8372B242A79B000734A42 /* HapMetalPixelBufferTexture.m */; };
+		84C83737242A79B000734A42 /* MetalHapDisplayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C8372C242A79B000734A42 /* MetalHapDisplayer.m */; };
+		84C83738242A79B000734A42 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 84C8372D242A79B000734A42 /* Shaders.metal */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -397,6 +403,19 @@
 		1AC0CA181A437C2A00A9BC2C /* HapEncoderFrame.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HapEncoderFrame.m; sourceTree = "<group>"; };
 		1ACF5DEB1A3E4127005DDF19 /* PixelFormats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = PixelFormats.c; path = source/PixelFormats.c; sourceTree = SOURCE_ROOT; };
 		1AE092DB1AFE96F4004E866B /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = ../../../../System/Library/Frameworks/VideoToolbox.framework; sourceTree = "<group>"; };
+		840B32C62417D9DD007CA678 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		840B32CB2417E796007CA678 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+		84C83726242A79B000734A42 /* TextureRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TextureRenderer.m; sourceTree = "<group>"; };
+		84C83727242A79B000734A42 /* MetalShaderTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalShaderTypes.h; sourceTree = "<group>"; };
+		84C83728242A79B000734A42 /* MetalImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MetalImageView.m; sourceTree = "<group>"; };
+		84C8372B242A79B000734A42 /* HapMetalPixelBufferTexture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HapMetalPixelBufferTexture.m; sourceTree = "<group>"; };
+		84C8372C242A79B000734A42 /* MetalHapDisplayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MetalHapDisplayer.m; sourceTree = "<group>"; };
+		84C8372D242A79B000734A42 /* Shaders.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
+		84C8372E242A79B000734A42 /* MetalImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalImageView.h; sourceTree = "<group>"; };
+		84C8372F242A79B000734A42 /* TextureRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureRenderer.h; sourceTree = "<group>"; };
+		84C83731242A79B000734A42 /* MetalHapDisplayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MetalHapDisplayer.h; sourceTree = "<group>"; };
+		84C83732242A79B000734A42 /* HapMetalPixelBufferTexture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HapMetalPixelBufferTexture.h; sourceTree = "<group>"; };
+		84F6F9362418F9D600E1C63D /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -404,7 +423,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A0518681A3E1DAB00FC80D2 /* CoreVideo.framework in Frameworks */,
+				840B32CC2417E796007CA678 /* MetalKit.framework in Frameworks */,
+				840B32C72417D9DD007CA678 /* Metal.framework in Frameworks */,
 				1A0518621A3E17DC00FC80D2 /* HapInAVFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -521,6 +541,7 @@
 		1A3230151A3BA14000DDB2E0 /* HapInAVF Test App */ = {
 			isa = PBXGroup;
 			children = (
+				84C83725242A79B000734A42 /* Metal */,
 				1A3230181A3BA14000DDB2E0 /* HapInAVFTestAppDelegate.h */,
 				1A3230191A3BA14000DDB2E0 /* HapInAVFTestAppDelegate.m */,
 				1A05185A1A3E17CF00FC80D2 /* GLView.h */,
@@ -591,6 +612,9 @@
 		1A6060711A38D8F5008E693F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				84F6F9362418F9D600E1C63D /* CoreImage.framework */,
+				840B32CB2417E796007CA678 /* MetalKit.framework */,
+				840B32C62417D9DD007CA678 /* Metal.framework */,
 				1A38F87420E64AFA00F47ACA /* Sparkle.framework */,
 				1A0518671A3E1DAB00FC80D2 /* CoreVideo.framework */,
 				1A680E291A39F67E007678E5 /* CoreMedia.framework */,
@@ -716,6 +740,23 @@
 				1AABDE8C207E544000D8F504 /* main.mm */,
 			);
 			path = AVFtoHap;
+			sourceTree = "<group>";
+		};
+		84C83725242A79B000734A42 /* Metal */ = {
+			isa = PBXGroup;
+			children = (
+				84C8372E242A79B000734A42 /* MetalImageView.h */,
+				84C83728242A79B000734A42 /* MetalImageView.m */,
+				84C8372F242A79B000734A42 /* TextureRenderer.h */,
+				84C83726242A79B000734A42 /* TextureRenderer.m */,
+				84C83731242A79B000734A42 /* MetalHapDisplayer.h */,
+				84C8372C242A79B000734A42 /* MetalHapDisplayer.m */,
+				84C83732242A79B000734A42 /* HapMetalPixelBufferTexture.h */,
+				84C8372B242A79B000734A42 /* HapMetalPixelBufferTexture.m */,
+				84C83727242A79B000734A42 /* MetalShaderTypes.h */,
+				84C8372D242A79B000734A42 /* Shaders.metal */,
+			);
+			path = Metal;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1034,9 +1075,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84C83736242A79B000734A42 /* HapMetalPixelBufferTexture.m in Sources */,
 				1A05185F1A3E17CF00FC80D2 /* HapPixelBufferTexture.m in Sources */,
 				1A32301C1A3BA14000DDB2E0 /* main.m in Sources */,
+				84C83734242A79B000734A42 /* MetalImageView.m in Sources */,
+				84C83738242A79B000734A42 /* Shaders.metal in Sources */,
 				1A32301A1A3BA14000DDB2E0 /* HapInAVFTestAppDelegate.m in Sources */,
+				84C83737242A79B000734A42 /* MetalHapDisplayer.m in Sources */,
+				84C83733242A79B000734A42 /* TextureRenderer.m in Sources */,
 				1A05185E1A3E17CF00FC80D2 /* GLView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1221,6 +1267,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "HapInAVF Test App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1254,6 +1301,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "HapInAVF Test App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
Hi,

Here's a metal implementation for the Test App Player

* Made to be identical to OpenGL view
* NSImage render in metal would need a framework change (OpenGL Code is used for RGB Buffers) so I skipped it for now
* There seems to be a slight color and position shift between OpenGL & Metal, that would need more investigation
* Deployment target set to 10.11. That's needed to play with CVBuffers in Metal which is used for the non-hap player
* I recon a few stutters on playback

What do you think? I am welcoming any feedback & ideas to improve this PR!